### PR TITLE
fix path for submodules

### DIFF
--- a/git_parser_cli/lib/git_parser_cli.dart
+++ b/git_parser_cli/lib/git_parser_cli.dart
@@ -31,7 +31,7 @@ class GitParserCli {
     );
 
     final gitfiles = await gitParser.parse();
-    final hitMap = GitParserUtils.generateDiffMap(gitfiles);
+    final hitMap = GitParserUtils.generateDiffMap(gitfiles, await GitParserUtils.getCurrentGitDir());
     await GitParserUtils.writeDiffMapToJson(hitMap, '${settings.outputDir}/.gitparser.json');
   }
 }

--- a/git_parser_cli/lib/parser/git_diff_parser.dart
+++ b/git_parser_cli/lib/parser/git_diff_parser.dart
@@ -67,8 +67,8 @@ class GitDiffParser extends GitParser<List<GitFile>> {
   @override
   Future<List<GitFile>> parse() async {
     // Construct the diff command for the target and fallback branches
-    final command = ['diff', '$targetBranch...$sourceBranch'];
-    final fallBack = ['diff', '$fallbackBranch...$sourceBranch'];
+    final command = ['diff', '$targetBranch..$sourceBranch'];
+    final fallBack = ['diff', '$fallbackBranch..$sourceBranch'];
 
     // Run the Git command and fallback if necessary
     await _runGitCommand(command, fallbackCommand: fallBack);

--- a/git_parser_cli/lib/utils/git_parser_utils.dart
+++ b/git_parser_cli/lib/utils/git_parser_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -23,15 +24,17 @@ class GitParserUtils {
     );
   }
 
-  static Map<String, Map<String, int>> generateDiffMap(List<GitFile> gitfiles) {
+  static Map<String, Map<String, int>> generateDiffMap(List<GitFile> gitfiles, String gitPath) {
     final Map<String, Map<String, int>> hitMap = {};
+    final cleanGitPath = gitPath.isEmpty ? '' : '$gitPath/';
     for (var file in gitfiles) {
-      hitMap[file.path] = {};
+      final path = '$cleanGitPath${file.path}';
+      hitMap[path] = {};
       for (var content in file.content) {
-        if(hitMap[file.path]![content.lineNumber] != null) {
-          hitMap[file.path]![content.lineNumber] = hitMap[file.path]![content.lineNumber]! + (content.isLineAdded ? 1 : 0);
+        if(hitMap[path]![content.lineNumber] != null) {
+          hitMap[path]![content.lineNumber] = hitMap[path]![content.lineNumber]! + (content.isLineAdded ? 1 : 0);
         } else {
-        hitMap[file.path]![content.lineNumber] = content.isLineAdded ? 1 : 0;
+        hitMap[path]![content.lineNumber] = content.isLineAdded ? 1 : 0;
         }
       }
     }
@@ -51,5 +54,17 @@ class GitParserUtils {
     } catch (e) {
       exitWithMessage(e.toString());
     }
+  }
+
+  static Future<String> getCurrentGitDir() async {
+    final process = await Process.run(
+      'git',
+      ['rev-parse', '--show-toplevel'],
+      runInShell: true,
+    );
+    if(process.exitCode != 0) {
+      return '';
+    }
+    return process.stdout.toString().trim();
   }
 }

--- a/lcov_cli/lib/generators/html_files_gen.dart
+++ b/lcov_cli/lib/generators/html_files_gen.dart
@@ -46,7 +46,7 @@ class HtmlFilesGen {
   }
 
   _FilePaths _getFilePaths(CodeFile file, String? rootPath, Directory outputDirectory) {
-    final relativeFilePath = rootPath != null ? file.path.replaceFirst(rootPath, '') : file.path;
+    final relativeFilePath = rootPath != null ? file.path.replaceFirst('$rootPath/', '') : file.path;
     final pathParts = relativeFilePath.split('/');
     final relativeDir = pathParts.sublist(0, pathParts.length - 1).join('/');
     final dir = Directory('${outputDirectory.path}/$relativeDir');

--- a/lcov_cli/lib/parsers/code_coverage_file_parser.dart
+++ b/lcov_cli/lib/parsers/code_coverage_file_parser.dart
@@ -34,7 +34,8 @@ class CodeCoverageFileParser extends LineParser {
   @override
   FutureOr<List<CodeFile>> parsedLines([String? rootPath]) {
     // Extract paths from coverage files.
-    final filePaths = coverageCodeFiles.map((file) => file.path).toList();
+    final fileRootPath = rootPath != null ? '$rootPath/' : '';
+    final filePaths = coverageCodeFiles.map((file) => fileRootPath +file.path).toList();
 
     final codeFiles = <CodeFile>[];
 
@@ -49,7 +50,7 @@ class CodeCoverageFileParser extends LineParser {
     final modifiedFilesByPath = {for (var file in modifiedCodeFiles ?? <CodeFile>[]) file.path: file};
 
     // Map of coverage files by file path.
-    final coverageFilesByPath = {for (var file in coverageCodeFiles) file.path: file};
+    final coverageFilesByPath = {for (var file in coverageCodeFiles) fileRootPath + file.path: file};
 
     // Process each file group (coverage files).
     for (var group in fileGroups) {

--- a/lcov_cli/lib/run.dart
+++ b/lcov_cli/lib/run.dart
@@ -18,7 +18,6 @@ class LcovCli {
     final outputDir = settings.outputDir;
 
     final projectPath = settings.projectPath ?? coverageFile.path.split('/coverage').firstOrNull;
-    print(projectPath);
     final parsedProjectDir = Directory(projectPath?.toString() ?? '');
 
     if (!parsedProjectDir.existsSync()) exitWithMessage('Cannot find project, please provide a valid project path --> $projectPath');
@@ -42,6 +41,6 @@ class LcovCli {
       modifiedCodeFiles: gitJsonParser != null ? await gitJsonParser.parsedLines(rootPath) : null,
     );
     final codeFiles = await totalCodeCoverageParser.parsedLines(rootPath);
-    await HtmlFilesGen().generateHtmlFiles(codeFiles, outputDir.path);
+    await HtmlFilesGen().generateHtmlFiles(codeFiles, outputDir.path, rootPath);
   }
 }

--- a/sample.sh
+++ b/sample.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+check_git_ignore() {
+    item_to_ignore="coverage/"
+    gitignore_file="$cur/.gitignore"
+
+    if ! grep -Fxq "$item_to_ignore" "$gitignore_file"; then
+        echo "$item_to_ignore" >> "$gitignore_file"
+        echo "$item_to_ignore has been added to $gitignore_file"
+    else
+        echo "$item_to_ignore is already in $gitignore_file"
+    fi
+}
+
+args=("$@")
+cur=$(pwd)
+pubspec_path="$cur/pubspec.yaml"
+target_branch="main"
+
+get_arg_value() {
+    local arg_name="$1"
+    for arg in "${args[@]}"; do
+        if [[ "$arg" == "$arg_name="* ]]; then
+            echo "${arg#*=}"
+            return
+        fi
+    done
+    echo ""
+}
+
+run_lcov_cli() {
+    dart ./git_parser_cli/bin/git_parser_cli.dart --target-branch="$target_branch" --source-branch=HEAD --output-dir="$cur/coverage"
+    dart ./lcov_cli/bin/lcov_cli.dart --lcov="$cur/coverage/lcov.info" --output="$cur/coverage/" --gitParserFile="$cur/coverage/.gitparser.json"
+
+    file_path="file://$cur/coverage/lcov_html/index.html"
+    echo "$file_path"
+
+
+    if [[ " ${args[@]} " =~ "open" ]]; then
+        open "$file_path"
+    else
+        read -p "Do you want to open the result? (y/n): " ans
+        case "$ans" in
+            y|Y ) open "$file_path"
+                ;;
+            n|N ) echo ""
+                ;;
+            * ) echo ""
+                ;;
+        esac
+    fi
+}
+
+target_branch_arg=$(get_arg_value "--target-branch")
+if [[ -n "$target_branch_arg" ]]; then
+    target_branch="$target_branch_arg"
+fi
+
+if [ -f "$pubspec_path" ]; then
+    flutter pub get
+    check_git_ignore
+
+
+    if [[ " ${args[@]} " =~ "--skip-coverage" ]]; then
+        echo "Skipping flutter test coverage..."
+    else
+        flutter test --coverage
+        lcov --remove coverage/lcov.info '*.g.dart' '*.part.dart' -o coverage/lcov.info
+    fi
+
+    run_lcov_cli
+   
+else
+    echo "$cur is not a flutter project directory. Enter a flutter package root directory."
+    run_lcov_cli
+fi


### PR DESCRIPTION
Fix: lcov_cli now correctly shows git diffs for submodules that aren't standalone repos.

Details:
Previously, if a submodule wasn’t a direct git repo (e.g., relying on the parent repo’s .git), lcov_cli wouldn’t pick up changes properly. This fixes that by ensuring it resolves the correct git context when submodules are involved.